### PR TITLE
Fix `undefined symbol: nfc_open`

### DIFF
--- a/python-nfc-pi-clock/nfc/Makefile
+++ b/python-nfc-pi-clock/nfc/Makefile
@@ -25,7 +25,7 @@ lib$(NAME).so: lib$(NAME).so.$(VERSION)
 	ln -s lib$(NAME).so.$(MAJOR) lib$(NAME).so
 
 lib$(NAME).so.$(VERSION): $(NAME).o
-	$(CC) -fPIC -O3 -shared -lnfc -Wl,-soname,lib$(NAME).so.$(MAJOR) $^ -o $@
+	$(CC) -fPIC -O3 -shared -Wl,-soname,lib$(NAME).so.$(MAJOR) $^ -o $@ -lnfc
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
This fixes a runtime error in the docker image. Due to dependency order, this resulted in the following error:
```
python-nfc-pi-clock-1  | Creating local state...
python-nfc-pi-clock-1  | Traceback (most recent call last):
python-nfc-pi-clock-1  |   File "/usr/src/app/src/app.py", line 74, in <module>
python-nfc-pi-clock-1  |     local_state = LocalState()
python-nfc-pi-clock-1  |                   ^^^^^^^^^^^^
python-nfc-pi-clock-1  |   File "/usr/src/app/src/app.py", line 27, in __init__
python-nfc-pi-clock-1  |     self.nfc_poll = NFCPoll()
python-nfc-pi-clock-1  |                     ^^^^^^^^^
python-nfc-pi-clock-1  |   File "/usr/src/app/src/nfc_poll.py", line 19, in __init__
python-nfc-pi-clock-1  |     self.libnfcutils = CDLL("libnfcutils.so")
python-nfc-pi-clock-1  |                        ^^^^^^^^^^^^^^^^^^^^^^
python-nfc-pi-clock-1  |   File "/usr/local/lib/python3.11/ctypes/__init__.py", line 376, in __init__
python-nfc-pi-clock-1  |     self._handle = _dlopen(self._name, mode)
python-nfc-pi-clock-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
python-nfc-pi-clock-1  | OSError: /lib/libnfcutils.so: undefined symbol: nfc_open
```

This commit fixes that.